### PR TITLE
メインクラスのエラー処理を修正．加え不要なインポートの削除

### DIFF
--- a/pycasl2/src/main/java/pycasl2/Error.java
+++ b/pycasl2/src/main/java/pycasl2/Error.java
@@ -1,7 +1,8 @@
 package pycasl2;
 
 class Error extends RuntimeException {
-    private final int lineNum;
+    private static final long serialVersionUID = 1L;
+		private final int lineNum;
     private final String src;
 
     Error(int lineNum, String src, String message) {

--- a/pycasl2/src/main/java/pycasl2/PyCasl2.java
+++ b/pycasl2/src/main/java/pycasl2/PyCasl2.java
@@ -1,7 +1,6 @@
 package pycasl2;
 
 import java.io.*;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
@@ -514,8 +513,8 @@ public class PyCasl2 {
                 }
                 casl2.write(comName, x);
             } catch (Exception e) {
-                System.err.println(e.getMessage());
-                System.exit(1);
+                System.err.println("An I/O error occurred while reading casl file: " + argList.get(0));
+                e.printStackTrace();
             }
         }
     }

--- a/pycomet2/src/main/java/pycomet2/PyComet2.java
+++ b/pycomet2/src/main/java/pycomet2/PyComet2.java
@@ -6,13 +6,12 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 
 public class PyComet2 implements Util {
     static class InvalidOperation extends RuntimeException {
+        private static final long serialVersionUID = 1L;
         private final int address;
 
         public InvalidOperation(int address) {
@@ -578,8 +577,8 @@ public class PyComet2 implements Util {
                     comet2.waitForCommand();
                 }
             } catch (IOException e) {
-                System.err.println("An I/O error occurred while reading comet file.");
-                System.exit(1);
+                System.err.println("An I/O error occurred while reading comet file: " + argList.get(0));
+                e.printStackTrace();
             }
         }
     }


### PR DESCRIPTION
3つ修正
- main()内でのSystem.exit(1); を削除
- main()内でのエラーメッセージを出力
- 不要なインポートの削除