### PR TITLE
mainに代わる実行用APIを追加

### DIFF
--- a/pycasl2/src/main/java/pycasl2/PyCasl2.java
+++ b/pycasl2/src/main/java/pycasl2/PyCasl2.java
@@ -452,8 +452,8 @@ public class PyCasl2 {
         return arg.startsWith("GR");
     }
 
-    private void write(String filename, ByteCode[] codeList) {
-        try (FileOutputStream fos = new FileOutputStream(new File(filename));
+    private void write(File file, ByteCode[] codeList) {
+        try (FileOutputStream fos = new FileOutputStream(file);
              DataOutputStream dos = new DataOutputStream(fos)) {
             for (ByteCode code : codeList) {
                 for (Object i : code.code) {
@@ -465,12 +465,11 @@ public class PyCasl2 {
         }
     }
 
-    public static void execute(final String inputFileName, final String outputFileName) {
-    	PyCasl2 casl2 = new PyCasl2();
-        ByteCode[] x;
+    public static void execute(final File inputFile, final File outputFile) {
 		try {
-			x = casl2.assemble(new File(inputFileName));
-	        casl2.write(outputFileName, x);
+            PyCasl2 casl2 = new PyCasl2();
+            ByteCode[] x = casl2.assemble(inputFile);
+	        casl2.write(outputFile, x);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -522,7 +521,7 @@ public class PyCasl2 {
                 if (dump) {
                     casl2.dump(x);
                 }
-                casl2.write(comName, x);
+                casl2.write(new File(comName), x);
             } catch (Exception e) {
                 System.err.println("An I/O error occurred while reading casl file: " + argList.get(0));
                 e.printStackTrace();

--- a/pycasl2/src/main/java/pycasl2/PyCasl2.java
+++ b/pycasl2/src/main/java/pycasl2/PyCasl2.java
@@ -465,7 +465,7 @@ public class PyCasl2 {
         }
     }
 
-    public static void execute(final String inputFileName, final String outputFileName, final String... args) {
+    public static void execute(final String inputFileName, final String outputFileName) {
     	PyCasl2 casl2 = new PyCasl2();
         ByteCode[] x;
 		try {

--- a/pycasl2/src/main/java/pycasl2/PyCasl2.java
+++ b/pycasl2/src/main/java/pycasl2/PyCasl2.java
@@ -465,6 +465,17 @@ public class PyCasl2 {
         }
     }
 
+    public static void execute(final String inputFileName, final String outputFileName, final String... args) {
+    	PyCasl2 casl2 = new PyCasl2();
+        ByteCode[] x;
+		try {
+			x = casl2.assemble(new File(inputFileName));
+	        casl2.write(outputFileName, x);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+    }
+    
     public static void main(String[] args) {
         String usage = "Usage: " + PyCasl2.class.getSimpleName() + " [options] input.cas [output.com]";
         List<String> argList = new ArrayList<>();

--- a/pycomet2/src/main/java/pycomet2/IN.java
+++ b/pycomet2/src/main/java/pycomet2/IN.java
@@ -1,5 +1,8 @@
 package pycomet2;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 class IN extends Instruction {
     IN(PyComet2 machine) {
         super(machine, 0x90, "IN", ArgType.StrLen);
@@ -10,9 +13,16 @@ class IN extends Instruction {
         int[] sl = this.getStrLen();
         int s = sl[0];
         int l = sl[1];
-        System.err.print("->");
-        System.err.flush();
-        String line = this.m.scanner.nextLine();
+        if (this.m.showInputArrow) {
+            System.err.print("->");
+            System.err.flush();
+        }
+        String line;
+        try {
+            line = this.m.in.readLine();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         if (256 < line.length()) {
             line = line.substring(0, 256);
         }

--- a/pycomet2/src/main/java/pycomet2/OUT.java
+++ b/pycomet2/src/main/java/pycomet2/OUT.java
@@ -1,5 +1,8 @@
 package pycomet2;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 class OUT extends Instruction {
     OUT(PyComet2 machine) {
         super(machine, 0x91, "OUT", ArgType.StrLen);
@@ -21,7 +24,16 @@ class OUT extends Instruction {
                 this.m.dump(s);
             }
         }
-        System.out.println(sb.toString());
+        try {
+            String line = sb.toString() + "\n";
+            if (this.m.out == null) {
+                System.out.print(line);
+            } else {
+                this.m.out.write(line);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         this.m.PR += 3;
     }
 }

--- a/pycomet2/src/main/java/pycomet2/PyComet2.java
+++ b/pycomet2/src/main/java/pycomet2/PyComet2.java
@@ -1,8 +1,24 @@
 package pycomet2;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.nio.file.Files;
-import java.util.*;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
@@ -479,6 +495,51 @@ public class PyComet2 implements Util {
         System.err.println("s             Step execution.");
         System.err.println("st            Dump 128 words of stack image.");
     }
+
+    public static void execute(final String inputFileName, final String outputFileName, final String... args) {
+    	final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	final PrintStream stdout = System.out;
+    	System.setOut(new PrintStream(out));
+
+		final StandardInputSnatcher in = new StandardInputSnatcher();
+		final InputStream stdin = System.in;
+		System.setIn(in);
+		for (final String line : args) {
+			in.inputln(line);
+		}
+
+        try {
+    	PyComet2 comet2 = new PyComet2();
+        comet2.setAutoDump(false);
+        comet2.setCountStep(false);
+		comet2.load(inputFileName, true);
+        comet2.run();
+        Files.write(Paths.get(outputFileName), out.toByteArray());
+
+        } catch (IOException e) {
+			e.printStackTrace();
+		}
+        System.setOut(stdout);
+        System.setIn(stdin);
+    }
+
+	static class StandardInputSnatcher extends InputStream {
+		private final StringBuilder buffer = new StringBuilder();
+
+		public void inputln(String str) {
+			this.buffer.append(str).append(System.lineSeparator());
+		}
+
+		@Override
+		public int read() throws IOException {
+			if (this.buffer.length() == 0) {
+				return -1;
+			}
+			final int result = this.buffer.charAt(0);
+			this.buffer.deleteCharAt(0);
+			return result;
+		}
+	}
 
     public static void main(String[] args) {
         boolean countStep = false;


### PR DESCRIPTION
mainに代わるpublicな実行用APIを，PyCasl/PyComet両方に追加した．
```java
public class PyCasl {
   public static void execute(final String inputFileName, final String outputFileName) {

public class PyComet {
   public static void execute(final String inputFileName, final String outputFileName, final String... args) {

```
これにより，lib化しておけば以下のような呼び出しが可能になる．テスト自動化ととても相性が良い．
```java
PyCasl2.execute("test.cas", "test.com");
PyComet2.execute("test.com", "test.ans");
```

PyCometへの標準入力はexecuteの第三引数（可変長引数）で与えることが可能．
```
PyComet2.execute("test.com", "test.ans", "36", "48");
```

リクエストしていたmain自体の改変#2（とそれに伴う実行時helpやREADMEの修正）は不要かもしれない．コーディングスタイルは統一していないので勘弁．